### PR TITLE
Postpone adding the LCA and component light electrical systems to the…

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lemsystems.cpp
@@ -690,6 +690,18 @@ void LEM::SystemsInit()
 	Panelsdk.AddElectrical(&INV_1, false);
 	Panelsdk.AddElectrical(&INV_2, false);
 
+	// Lighting wiring
+	Panelsdk.AddElectrical(&lca.CDR_Bus_28V_6V_Converter, false);
+	Panelsdk.AddElectrical(&lca.LMP_Bus_28V_6V_Converter, false);
+	Panelsdk.AddElectrical(&lca.Fixed_5_5VDC_Output, false);
+	Panelsdk.AddElectrical(&lca.Fixed_6VDC_Output, false);
+	Panelsdk.AddElectrical(&lca.Variable_2_5VDC_Output, false);
+
+	Panelsdk.AddElectrical(&lca.Num_Override_20_110VAC_Output, false);
+	Panelsdk.AddElectrical(&lca.Int_Override_15_75VAC_Output, false);
+
+	Panelsdk.AddElectrical(&ComponentLights.Feeder_6VDC_Output, false);
+
 	// ECS
 	CabinPressureSwitch.Init((h_Tank *)Panelsdk.GetPointerByString("HYDRAULIC:CABIN"), 4.70/PSI, 4.07/PSI);
 	SuitPressureSwitch.Init((h_Tank *)Panelsdk.GetPointerByString("HYDRAULIC:SUITCIRCUIT"), 3.50/PSI, 2.90/PSI);

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_eps.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_eps.cpp
@@ -1218,15 +1218,6 @@ LEM_LCA::LEM_LCA(PanelSDK& p) :
 {
 	lem = NULL;
 	LCAHeat = 0;
-
-	p.AddElectrical(&CDR_Bus_28V_6V_Converter, false);
-	p.AddElectrical(&LMP_Bus_28V_6V_Converter, false);
-	p.AddElectrical(&Fixed_5_5VDC_Output, false);
-	p.AddElectrical(&Fixed_6VDC_Output, false);
-	p.AddElectrical(&Variable_2_5VDC_Output, false);
-
-	p.AddElectrical(&Num_Override_20_110VAC_Output, false);
-	p.AddElectrical(&Int_Override_15_75VAC_Output, false);
 }
 
 void LEM_LCA::Init(LEM *l, e_object *cdrcb, e_object *lmpcb, e_object *acnumcb, e_object *acintcb, h_HeatLoad *lca_h)
@@ -1603,8 +1594,6 @@ LEM_ComponentLights::LEM_ComponentLights(PanelSDK& p) :
 	FixedPower = NULL;
 	CDR_Feed = NULL;
 	LMP_Feed = NULL;
-
-	p.AddElectrical(&Feeder_6VDC_Output, false);
 
 	NoTrack = false;
 	CO2 = false;

--- a/Orbitersdk/samples/ProjectApollo/src_lm/lm_eps.h
+++ b/Orbitersdk/samples/ProjectApollo/src_lm/lm_eps.h
@@ -355,10 +355,6 @@ public:
 	//Variable 15-75VAC integral transformer
 	RotVoltageTransformerOverride Int_Override_15_75VAC_Output;
 
-protected:
-	LEM *lem;
-	h_HeatLoad *LCAHeat;
-
 	// Internal annunciator wiring
 	// CDR bus 28VDC to 6VDC converter
 	FixedVoltageTransformer CDR_Bus_28V_6V_Converter;
@@ -366,6 +362,10 @@ protected:
 	FixedVoltageTransformer LMP_Bus_28V_6V_Converter;
 	// CDR and LMP DC bus power merge
 	PowerMerge NumDockCompLTGFeeder;
+
+protected:
+	LEM *lem;
+	h_HeatLoad *LCAHeat;
 };
 
 class LEM_UtilLights


### PR DESCRIPTION
… Panelsdk until after the rest of the EPS has been added; this allows the LCA to get a voltage on the first timestep